### PR TITLE
Changing code to reproduce deadline exceeded error

### DIFF
--- a/src/client/client.go
+++ b/src/client/client.go
@@ -5,10 +5,9 @@ import (
 	"io"
 	"log"
 	"math/rand"
+	"time"
 
 	pb "github.com/pahanini/go-grpc-bidirectional-streaming-example/src/proto"
-
-	"time"
 
 	"google.golang.org/grpc"
 )
@@ -24,13 +23,21 @@ func main() {
 
 	// create stream
 	client := pb.NewMathClient(conn)
-	stream, err := client.Max(context.Background())
+	streamContext, _ := context.WithTimeout(context.Background(), time.Second)
+	stream, err := client.Max(streamContext)
 	if err != nil {
 		log.Fatalf("openn stream error %v", err)
 	}
 
 	var max int32
 	ctx := stream.Context()
+
+	deadline, ok := ctx.Deadline()
+	if ok {
+		log.Println("Deadline set: ", deadline)
+	} else {
+		log.Println("Deadline not set")
+	}
 	done := make(chan bool)
 
 	// first goroutine sends random increasing numbers to stream

--- a/src/server/server.go
+++ b/src/server/server.go
@@ -4,6 +4,7 @@ import (
 	"io"
 	"log"
 	"net"
+	"time"
 
 	pb "github.com/pahanini/go-grpc-bidirectional-streaming-example/src/proto"
 
@@ -21,6 +22,7 @@ func (s server) Max(srv pb.Math_MaxServer) error {
 	ctx := srv.Context()
 
 	for {
+		time.Sleep(time.Second * 2)
 
 		// exit if context is done
 		// or continue


### PR DESCRIPTION
Here is the client logs:

Type 1: error while receiving the response.
```
princer@princer0:~/code/go-grpc-bidirectional-streaming-example$ ./client
2024/05/03 07:17:27 Deadline set:  2024-05-03 07:17:28.686355163 +0000 UTC m=+1.006100310
2024/05/03 07:17:27 0 sent
2024/05/03 07:17:27 0 sent
2024/05/03 07:17:28 0 sent
2024/05/03 07:17:28 0 sent
2024/05/03 07:17:28 4 sent
2024/05/03 07:17:28 can not receive rpc error: code = DeadlineExceeded desc = context deadline exceeded
```

Type 2: error context cancelled before only:
```
2024/05/03 07:17:23 Deadline set:  2024-05-03 07:17:24.063918933 +0000 UTC m=+1.005888171
2024/05/03 07:17:23 0 sent
2024/05/03 07:17:23 1 sent
2024/05/03 07:17:23 1 sent
2024/05/03 07:17:23 3 sent
2024/05/03 07:17:23 3 sent
2024/05/03 07:17:24 context deadline exceeded
2024/05/03 07:17:24 finished with max=0
```
